### PR TITLE
[update] 升级 xgplayer 版本，切换 cdn 为 byted-static

### DIFF
--- a/views/tmpl/play.html
+++ b/views/tmpl/play.html
@@ -99,16 +99,20 @@
 {{template "footer" .}}
 
 {{if eq .playType "m3u8"}}
-<script src="//cdn.jsdelivr.net/npm/xgplayer@2.9.6/browser/index.js" type="text/javascript"></script>
-<script src="//sf1-ttcdn-tos.pstatp.com/obj/unpkg/xgplayer-hls.js/2.2.2/browser/index.js" charset="utf-8"></script>
+<link rel="stylesheet" href="//unpkg.byted-static.com/xgplayer/3.0.18/dist/index.min.css">
+<script src="//unpkg.byted-static.com/xgplayer/3.0.18/dist/index.min.js"></script>
+<script src="//unpkg.byted-static.com/xgplayer-hls/3.0.18/dist/index.min.js"></script>
 <script>
-	new window.HlsJsPlayer({
+	new window.Player({
+		plugins: [window.HlsPlayer],
 		id: 'hls-video',
 		url: '{{.playUrl}}',
 		fluid: true,
 		autoplay: true,
 		playbackRate: [0.5, 0.75, 1, 1.5, 2],
-		defaultPlaybackRate: 1
+		defaultPlaybackRate: 1,
+		height: '100%',
+  		width: '100%',
 	});
 </script>
 {{end}}


### PR DESCRIPTION
- 把  xgplayer  的 cdn 从 jsdelivr 切换为 byted-static 。因为 jsdelivr 在国内已被屏蔽。
- 把 xgplayer 的版本从 2.9.6 升级到 3.0.18。
